### PR TITLE
LPS-116357 Fix problems with REST Builder Project Template gradle build

### DIFF
--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-impl/rest-config.yaml
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-impl/rest-config.yaml
@@ -11,4 +11,4 @@ application:
     name: "${applicationName}"
 author: "${author}"
 clientDir: "../${artifactId}-client/src/main/java"
-testDir: "../${artifactId}-test/src/main/java"
+testDir: "../${artifactId}-test/src/testIntegration/java"

--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/bnd.bnd
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: ${artifactId}-test
 Bundle-SymbolicName: ${package}.test
 Bundle-Version: ${version}
--includeresource: ${package}.client.jar=${artifactId}-client-*.jar;lib:=true
+-includeresource: ${package}.client.jar=../${artifactId}-client/build/libs/${package}.client-${version}.jar;lib:=true

--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/build.gradle
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/build.gradle
@@ -25,3 +25,9 @@ dependencies {
 	testIntegrationCompile project("${apiPath}")
 	testIntegrationCompile project("${clientPath}")
 }
+
+configurations.all {
+	resolutionStrategy {
+		force group: 'com.liferay.portal', name: 'com.liferay.portal.test', version: '7.1.0'
+	}
+}

--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/build.gradle
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.10.3"
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.10.3"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.arquillian.extension.junit.bridge", version: "1.0.19"
+	testIntegrationCompile group: "com.liferay", name: "com.liferay.petra.io"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.petra.reflect"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.petra.string"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.portal.odata.api"
@@ -20,6 +21,7 @@ dependencies {
 #if (!${liferayVersion.startsWith("7.1")})
 	testIntegrationCompile group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 #end
+	testIntegrationCompile group: "org.slf4j", name: "slf4j-api"
 	testIntegrationCompile project("${apiPath}")
 	testIntegrationCompile project("${clientPath}")
 }

--- a/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/pom.xml
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/main/resources/archetype-resources/__artifactId__-test/pom.xml
@@ -40,6 +40,10 @@
 		</dependency>
 		<dependency>
 			<groupId>com.liferay</groupId>
+			<artifactId>com.liferay.petra.io</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.liferay</groupId>
 			<artifactId>com.liferay.petra.reflect</artifactId>
 		</dependency>
 		<dependency>
@@ -108,6 +112,10 @@
 			<scope>provided</scope>
 		</dependency>
 #end
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>${groupId}</groupId>
 			<artifactId>${artifactId}-api</artifactId>


### PR DESCRIPTION
Working in the gradle build error you mentioned last week I found a few problems.

The one that I've been fighting a lot with is that, when running integration tests, the com.liferay.portal.test that was resolved to version 3.0.0 due to the plugin that provides the testModule (I think is the test integration plugin)
```
testModules - Configures additional OSGi modules to deploy during integration testing.
+--- com.liferay:com.liferay.arquillian.extension.junit.bridge.connector:1.0.0
+--- com.liferay.portal:com.liferay.portal.test:3.0.0
\--- org.apache.aries.jmx:org.apache.aries.jmx.core:1.1.7
     +--- org.apache.aries.jmx:org.apache.aries.jmx.api:1.1.5
     \--- org.apache.aries:org.apache.aries.util:1.1.1
```

I forced the dependency to the one that we need to run the REST Builder integration tests but it would be better to upgrade this plugin to use an updated version of the test package.

Please check if this make sense to you and I don't know if there are any extra steps to update the REST Builder Project template to include this changes.

Thank you very much!
